### PR TITLE
Fix U affix entry.

### DIFF
--- a/src/eo-aff.m4
+++ b/src/eo-aff.m4
@@ -591,8 +591,8 @@ flag *F:
 ifdef({SXPARE},
 {   nome(I,-I,ANTIN)	# danci -> dancantino
     nomo(I,,NTIN)	# naski -> naskintino
-    nome(U,-I,ANTIN)	# dancu -> dancantino
-    nomo(U,,NTIN)})	# nasku -> naskintino
+    nome(U,-U,ANTIN)	# dancu -> dancantino
+    nomo(U,-U,INTIN)})	# nasku -> naskintino
     kazoj({O	>	-O,A})
     O		>	-O,E
     O		>	-O,INE


### PR DESCRIPTION
Hi, Sergio,

I am upgrading esperanto Debian package to your version available from https://kovro.heliohost.org/eo/tools/ispelleo.tar.bz2. aspell affix file is generated from original ispell affix file by means of ispellaff2myspell, a conversion tool I wrote a while ago to convert from ispell affix format to old myspell2 affix format that is supported by aspell.

To have aspell work with the resulting file I had to do a couple of things.

1) Seems aspell does not like the '\' flag and triggers an error. I changed it to '!' in .aff and .dic files and seems to go well.

2) There seems to be a problem with one of the affix rules (U) and aspell complains about it when building eo aspell hash. Error message is

Error: /usr/lib/aspell//eo_affix.dat:406: The condition "u" does not guarantee that "i" can always be stripped.

Looking at 'U' flag I think aspell seems right about this. I would expect this merge request to make 'U' flag behave as expected.

Regards,


